### PR TITLE
Add in-memory meeting room booking manager

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+.PHONY: install test dash lint
+
+install:
+	python -m pip install --upgrade pip
+	python -m pip install -r requirements.txt
+
+test:
+	python -m unittest discover -s tests -p 'test*.py' -v
+
+dash:
+	python dash_app.py
+
+lint:
+	python -m compileall meeting_room_booking.py dash_app.py

--- a/README.md
+++ b/README.md
@@ -86,6 +86,22 @@ You can work through the notebooks locally or in your browser. Pick the installa
 
 This repository now ships with an end-to-end example that demonstrates how to manage meeting rooms programmatically and through a Dash-powered dashboard.
 
+#### TL;DR Quick Start
+
+If you already have Python 3.8–3.11 and `make` installed, you can get up and running with the following commands from the project root:
+
+```bash
+$ python -m venv .venv           # create an isolated environment (optional but recommended)
+$ source .venv/bin/activate      # On Windows use: .venv\Scripts\activate
+(.venv) $ make install           # install app + dashboard dependencies
+(.venv) $ make test              # run the unit tests
+(.venv) $ make dash              # start the dashboard at http://127.0.0.1:8050
+```
+
+> **Note**: If `make` is unavailable on your platform, see the [detailed walkthrough](./docs/meeting_room_quickstart.md) for equivalent one-line commands.
+
+#### Detailed Walkthrough
+
 1. Activate the environment you created in the previous step (for example `conda activate pandas_workshop` or `source pandas_workshop/bin/activate`).
 2. Install the required dependencies:
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,32 @@ You can work through the notebooks locally or in your browser. Pick the installa
     ![check env](./media/env_check.png)
 
 
+### Meeting Room Booking Demo
+
+This repository now ships with an end-to-end example that demonstrates how to manage meeting rooms programmatically and through a Dash-powered dashboard.
+
+1. Activate the environment you created in the previous step (for example `conda activate pandas_workshop` or `source pandas_workshop/bin/activate`).
+2. Install the required dependencies:
+
+    ```bash
+    (pandas_workshop) ~/pandas-workshop$ pip install -r requirements.txt
+    ```
+
+3. Run the automated tests for the booking manager logic:
+
+    ```bash
+    (pandas_workshop) ~/pandas-workshop$ python -m unittest discover -s tests -p 'test*.py' -v
+    ```
+
+4. Launch the interactive dashboard locally:
+
+    ```bash
+    (pandas_workshop) ~/pandas-workshop$ python dash_app.py
+    ```
+
+5. Open your browser to the address shown in the terminal (by default <http://127.0.0.1:8050>) to manage rooms, create bookings, check availability, and view the reservation timeline.
+
+
 ### Cloud Options
 
 #### GitHub Codespaces

--- a/dash_app.py
+++ b/dash_app.py
@@ -1,0 +1,374 @@
+"""Dash application providing a UI for the meeting room booking manager."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Dict, List, Tuple
+
+import dash
+from dash import Dash, Input, Output, State, dash_table, dcc, html
+import plotly.express as px
+
+from meeting_room_booking import BookingManager, MeetingRoom
+
+
+def _serialize_room(room: MeetingRoom) -> Dict[str, str]:
+    return {
+        "name": room.name,
+        "capacity": room.capacity,
+        "resources": ", ".join(sorted(room.resources)) or "None",
+    }
+
+
+def _serialize_booking(manager: BookingManager) -> List[Dict[str, str]]:
+    serialized: List[Dict[str, str]] = []
+    for booking in manager.list_bookings():
+        serialized.append(
+            {
+                "id": booking.id,
+                "room": booking.room.name,
+                "start": booking.start.isoformat(timespec="minutes"),
+                "end": booking.end.isoformat(timespec="minutes"),
+                "title": booking.title,
+                "organizer": booking.organizer,
+                "attendees": ", ".join(booking.attendees) or "None",
+                "notes": booking.notes or "",
+            }
+        )
+    return serialized
+
+
+def _serialize_availability(manager: BookingManager, start: datetime, end: datetime) -> List[Dict[str, str]]:
+    rows: List[Dict[str, str]] = []
+    for room in manager.find_available_rooms(start, end):
+        rows.append(_serialize_room(room))
+    return rows
+
+
+def _get_datetime_range(start_value: str, end_value: str) -> Tuple[datetime, datetime]:
+    try:
+        start = datetime.fromisoformat(start_value)
+        end = datetime.fromisoformat(end_value)
+    except ValueError as exc:
+        raise ValueError("Please provide valid start and end datetimes.") from exc
+    if start >= end:
+        raise ValueError("Start time must be before end time.")
+    return start, end
+
+
+booking_manager = BookingManager()
+
+
+app: Dash = dash.Dash(__name__)
+app.title = "Meeting Room Booking Dashboard"
+
+
+def _initial_state() -> Dict[str, List[Dict[str, str]]]:
+    return {
+        "rooms": [_serialize_room(room) for room in booking_manager.list_rooms()],
+        "bookings": _serialize_booking(booking_manager),
+    }
+
+
+def layout() -> html.Div:
+    return html.Div(
+        [
+            html.H1("Meeting Room Booking Dashboard"),
+            dcc.Store(id="booking-state", data=_initial_state()),
+            html.Div(
+                [
+                    html.H2("Register a New Room"),
+                    html.Div(
+                        [
+                            dcc.Input(id="room-name", type="text", placeholder="Room name"),
+                            dcc.Input(
+                                id="room-capacity",
+                                type="number",
+                                placeholder="Capacity",
+                                min=1,
+                                step=1,
+                            ),
+                            dcc.Input(
+                                id="room-resources",
+                                type="text",
+                                placeholder="Resources (comma separated)",
+                            ),
+                            html.Button("Add Room", id="add-room-button", n_clicks=0),
+                        ],
+                        className="room-form",
+                    ),
+                    html.Div(id="room-feedback", className="feedback"),
+                    dash_table.DataTable(
+                        id="rooms-table",
+                        columns=[
+                            {"name": "Room", "id": "name"},
+                            {"name": "Capacity", "id": "capacity"},
+                            {"name": "Resources", "id": "resources"},
+                        ],
+                        data=[],
+                        style_table={"maxHeight": "250px", "overflowY": "auto"},
+                        style_cell={"textAlign": "left", "padding": "0.5rem"},
+                    ),
+                ],
+                className="rooms-section",
+            ),
+            html.Hr(),
+            html.Div(
+                [
+                    html.H2("Create a Booking"),
+                    html.Div(
+                        [
+                            dcc.Dropdown(id="booking-room", placeholder="Select a room"),
+                            dcc.Input(id="booking-title", type="text", placeholder="Meeting title"),
+                            dcc.Input(id="booking-organizer", type="email", placeholder="Organizer email"),
+                            dcc.Input(
+                                id="booking-attendees",
+                                type="text",
+                                placeholder="Attendees (comma separated emails)",
+                            ),
+                            dcc.Input(id="booking-start", type="datetime-local"),
+                            dcc.Input(id="booking-end", type="datetime-local"),
+                            dcc.Input(id="booking-notes", type="text", placeholder="Notes"),
+                            html.Button("Book Room", id="book-room-button", n_clicks=0),
+                        ],
+                        className="booking-form",
+                    ),
+                    html.Div(id="booking-feedback", className="feedback"),
+                    dash_table.DataTable(
+                        id="bookings-table",
+                        columns=[
+                            {"name": "ID", "id": "id"},
+                            {"name": "Room", "id": "room"},
+                            {"name": "Start", "id": "start"},
+                            {"name": "End", "id": "end"},
+                            {"name": "Title", "id": "title"},
+                            {"name": "Organizer", "id": "organizer"},
+                            {"name": "Attendees", "id": "attendees"},
+                            {"name": "Notes", "id": "notes"},
+                        ],
+                        data=[],
+                        style_table={"maxHeight": "300px", "overflowY": "auto"},
+                        style_cell={"textAlign": "left", "padding": "0.5rem"},
+                    ),
+                ],
+                className="bookings-section",
+            ),
+            html.Hr(),
+            html.Div(
+                [
+                    html.H2("Check Availability"),
+                    html.Div(
+                        [
+                            dcc.Input(id="availability-start", type="datetime-local"),
+                            dcc.Input(id="availability-end", type="datetime-local"),
+                            dcc.Input(
+                                id="availability-capacity",
+                                type="number",
+                                min=1,
+                                placeholder="Minimum capacity",
+                            ),
+                            dcc.Input(
+                                id="availability-resources",
+                                type="text",
+                                placeholder="Required resources (comma separated)",
+                            ),
+                            html.Button("Find Available Rooms", id="availability-button", n_clicks=0),
+                        ],
+                        className="availability-form",
+                    ),
+                    html.Div(id="availability-feedback", className="feedback"),
+                    dash_table.DataTable(
+                        id="availability-table",
+                        columns=[
+                            {"name": "Room", "id": "name"},
+                            {"name": "Capacity", "id": "capacity"},
+                            {"name": "Resources", "id": "resources"},
+                        ],
+                        data=[],
+                        style_table={"maxHeight": "200px", "overflowY": "auto"},
+                        style_cell={"textAlign": "left", "padding": "0.5rem"},
+                    ),
+                ],
+                className="availability-section",
+            ),
+            html.Hr(),
+            html.Div(
+                [
+                    html.H2("Bookings Timeline"),
+                    dcc.Graph(id="bookings-timeline"),
+                ],
+                className="timeline-section",
+            ),
+        ],
+        className="app-container",
+    )
+
+
+app.layout = layout()
+
+
+@app.callback(
+    Output("booking-state", "data"),
+    Output("room-feedback", "children"),
+    Input("add-room-button", "n_clicks"),
+    State("room-name", "value"),
+    State("room-capacity", "value"),
+    State("room-resources", "value"),
+    prevent_initial_call=True,
+)
+def add_room(
+    n_clicks: int,
+    name: str,
+    capacity_value,
+    resources: str,
+) -> Tuple[Dict[str, List[Dict[str, str]]], str]:
+    try:
+        if not name or capacity_value in (None, ""):
+            raise ValueError("Room name and capacity are required.")
+        resource_items = [res.strip() for res in (resources or "").split(",") if res.strip()]
+        booking_manager.add_room(
+            MeetingRoom(
+                name=name,
+                capacity=int(capacity_value),
+                resources=frozenset(resource_items),
+            )
+        )
+        message = f"Room '{name}' added successfully."
+    except Exception as exc:  # pylint: disable=broad-except
+        message = f"Error: {exc}"
+    return _initial_state(), message
+
+
+@app.callback(
+    Output("booking-state", "data", allow_duplicate=True),
+    Output("booking-feedback", "children"),
+    Input("book-room-button", "n_clicks"),
+    State("booking-room", "value"),
+    State("booking-title", "value"),
+    State("booking-organizer", "value"),
+    State("booking-attendees", "value"),
+    State("booking-start", "value"),
+    State("booking-end", "value"),
+    State("booking-notes", "value"),
+    prevent_initial_call=True,
+)
+def create_booking(
+    n_clicks: int,
+    room_name: str,
+    title: str,
+    organizer: str,
+    attendees: str,
+    start_value: str,
+    end_value: str,
+    notes: str,
+) -> Tuple[Dict[str, List[Dict[str, str]]], str]:
+    try:
+        if not room_name:
+            raise ValueError("Please select a room to book.")
+        if not organizer:
+            raise ValueError("Organizer email is required.")
+        if not start_value or not end_value:
+            raise ValueError("Start and end times are required.")
+        start, end = _get_datetime_range(start_value, end_value)
+        attendee_list = [item.strip() for item in (attendees or "").split(",") if item.strip()]
+        booking_manager.book_room(
+            room_name=room_name,
+            start=start,
+            end=end,
+            title=title or room_name,
+            organizer=organizer,
+            attendees=attendee_list,
+            notes=notes,
+        )
+        message = "Booking created successfully."
+    except Exception as exc:  # pylint: disable=broad-except
+        message = f"Error: {exc}"
+    return _initial_state(), message
+
+
+@app.callback(
+    Output("rooms-table", "data"),
+    Output("bookings-table", "data"),
+    Output("booking-room", "options"),
+    Input("booking-state", "data"),
+)
+def refresh_tables(state: Dict[str, List[Dict[str, str]]]):
+    rooms = state.get("rooms", [])
+    bookings = state.get("bookings", [])
+    room_options = [{"label": room["name"], "value": room["name"]} for room in rooms]
+    return rooms, bookings, room_options
+
+
+@app.callback(
+    Output("bookings-timeline", "figure"),
+    Input("booking-state", "data"),
+)
+def update_timeline(state: Dict[str, List[Dict[str, str]]]):
+    bookings = state.get("bookings", [])
+    if not bookings:
+        return px.scatter(title="No bookings available")
+    timeline_rows = []
+    for record in bookings:
+        try:
+            start = datetime.fromisoformat(record["start"])
+            end = datetime.fromisoformat(record["end"])
+        except ValueError:
+            # Fallback to raw strings if conversion fails
+            start = record["start"]
+            end = record["end"]
+        timeline_rows.append({**record, "start": start, "end": end})
+    fig = px.timeline(
+        timeline_rows,
+        x_start="start",
+        x_end="end",
+        y="room",
+        color="organizer",
+        hover_data=["title", "attendees", "notes"],
+        title="Bookings Timeline",
+    )
+    fig.update_yaxes(autorange="reversed")
+    return fig
+
+
+@app.callback(
+    Output("availability-table", "data"),
+    Output("availability-feedback", "children"),
+    Input("availability-button", "n_clicks"),
+    State("availability-start", "value"),
+    State("availability-end", "value"),
+    State("availability-capacity", "value"),
+    State("availability-resources", "value"),
+    prevent_initial_call=True,
+)
+def find_availability(
+    n_clicks: int,
+    start_value: str,
+    end_value: str,
+    capacity_value: str,
+    resources_value: str,
+):
+    try:
+        if not start_value or not end_value:
+            raise ValueError("Start and end times are required.")
+        start, end = _get_datetime_range(start_value, end_value)
+        capacity = int(capacity_value) if capacity_value not in (None, "") else None
+        resource_items = [item.strip() for item in (resources_value or "").split(",") if item.strip()]
+        data = _serialize_availability(booking_manager, start, end)
+        if capacity is not None:
+            data = [row for row in data if int(row["capacity"]) >= capacity]
+        if resource_items:
+            requested = set(resource_items)
+            filtered = []
+            for row in data:
+                resources = [] if row["resources"] == "None" else row["resources"].split(", ")
+                if requested.issubset(set(resources)):
+                    filtered.append(row)
+            data = filtered
+        message = f"Found {len(data)} available room(s)."
+    except Exception as exc:  # pylint: disable=broad-except
+        data = []
+        message = f"Error: {exc}"
+    return data, message
+
+
+if __name__ == "__main__":
+    app.run_server(debug=True)

--- a/docs/meeting_room_quickstart.md
+++ b/docs/meeting_room_quickstart.md
@@ -1,0 +1,71 @@
+# Meeting Room Booking Quick Start
+
+This guide walks you through running the meeting-room booking example from scratch on macOS, Linux, or Windows.
+
+## 1. Install Python
+Make sure Python 3.8, 3.9, 3.10, or 3.11 is installed. On Windows you can download it from [python.org](https://www.python.org/downloads/windows/), or install [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to get both Python and `conda`.
+
+## 2. Open a Terminal
+* **Windows**: Use *Command Prompt*, *PowerShell*, or *Windows Terminal*. If you installed Miniconda/Anaconda, open the **Anaconda Prompt**.
+* **macOS/Linux**: Use your default terminal app.
+
+All remaining commands should be typed in the terminal window.
+
+## 3. Clone the Project
+```bash
+$ git clone https://github.com/stefmolin/pandas-workshop.git
+$ cd pandas-workshop
+```
+
+If you downloaded the ZIP instead of cloning, unzip it and `cd` into the unzipped folder before continuing.
+
+## 4. Create & Activate a Virtual Environment (Recommended)
+```bash
+$ python -m venv .venv
+# macOS/Linux
+$ source .venv/bin/activate
+# Windows (Command Prompt)
+> .venv\Scripts\activate
+```
+Your prompt should now start with `(.venv)` (or `(pandas_workshop)` if using `conda`).
+
+## 5. Install Dependencies
+You can either use the `make` helper or run the equivalent `pip` command directly.
+
+### Option A: With `make`
+```bash
+(.venv) $ make install
+```
+
+### Option B: Without `make`
+```bash
+(.venv) $ python -m pip install --upgrade pip
+(.venv) $ python -m pip install -r requirements.txt
+```
+
+## 6. Run the Automated Tests (Optional but Recommended)
+```bash
+(.venv) $ make test          # or: python -m unittest discover -s tests -p "test*.py" -v
+```
+
+A successful run ends with `OK`.
+
+## 7. Launch the Dashboard
+```bash
+(.venv) $ make dash          # or: python dash_app.py
+```
+
+The Dash development server will print an address such as `http://127.0.0.1:8050/`. Open that link in your browser to access the interface.
+
+## 8. Stop the Dashboard
+Press `Ctrl+C` in the terminal window running the server.
+
+## 9. Deactivate the Virtual Environment (When Finished)
+```bash
+(.venv) $ deactivate
+```
+
+You can always re-activate the environment later and repeat steps 6–8.
+
+---
+Need help? Double-check each command for typos and ensure you are running them from the project directory (`pandas-workshop`).

--- a/meeting_room_booking.py
+++ b/meeting_room_booking.py
@@ -1,0 +1,326 @@
+"""Utilities for managing meeting room bookings.
+
+This module provides a small in-memory booking manager that can be used to
+track meeting rooms, create bookings, check availability, and update or cancel
+existing reservations.  The design keeps the public API intentionally
+lightweight so that it can be embedded inside other tools such as CLI scripts,
+web applications, or notebooks.
+
+Example
+-------
+>>> from datetime import datetime, timedelta
+>>> from meeting_room_booking import BookingManager, MeetingRoom
+>>> manager = BookingManager()
+>>> manager.add_room(MeetingRoom(name="Atlas", capacity=10, resources={"TV"}))
+>>> start = datetime(2024, 1, 1, 9, 0)
+>>> end = start + timedelta(hours=1)
+>>> booking = manager.book_room(
+...     room_name="Atlas",
+...     start=start,
+...     end=end,
+...     title="Product Sync",
+...     organizer="alex@example.com",
+...     attendees=["sam@example.com"],
+... )
+>>> manager.find_available_rooms(start, end)
+[]
+>>> manager.cancel_booking(booking.id)
+>>> manager.find_available_rooms(start, end)[0].name
+'Atlas'
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Iterable, List, Optional, Sequence, Set
+import uuid
+
+
+@dataclass(frozen=True)
+class MeetingRoom:
+    """Metadata describing an individual meeting room."""
+
+    name: str
+    capacity: int
+    resources: frozenset[str] = field(default_factory=frozenset)
+
+    def __post_init__(self) -> None:
+        normalized_name = self.name.strip()
+        if not normalized_name:
+            raise ValueError("Room name must not be empty.")
+        if self.capacity <= 0:
+            raise ValueError("Room capacity must be a positive integer.")
+        normalized_resources = frozenset(sorted(r.strip() for r in self.resources if r.strip()))
+        object.__setattr__(self, "name", normalized_name)
+        object.__setattr__(self, "resources", normalized_resources)
+
+
+@dataclass
+class Booking:
+    """Represents a reservation of a meeting room for a time interval."""
+
+    id: str
+    room: MeetingRoom
+    start: datetime
+    end: datetime
+    title: str
+    organizer: str
+    attendees: List[str] = field(default_factory=list)
+    notes: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        if self.start >= self.end:
+            raise ValueError("Booking start time must be before end time.")
+        self.attendees = [attendee.strip() for attendee in self.attendees if attendee.strip()]
+
+    def overlaps(self, other: "Booking") -> bool:
+        """Return ``True`` if this booking overlaps with ``other`` for the same room."""
+
+        if self.room.name != other.room.name:
+            return False
+        return self.start < other.end and other.start < self.end
+
+
+class BookingManager:
+    """Manage meeting rooms and their bookings in memory."""
+
+    def __init__(self) -> None:
+        self._rooms: Dict[str, MeetingRoom] = {}
+        self._bookings: Dict[str, Booking] = {}
+        self._room_index: Dict[str, List[str]] = {}
+
+    # ------------------------------------------------------------------
+    # Room management
+    # ------------------------------------------------------------------
+    def add_room(self, room: MeetingRoom) -> None:
+        """Register a new meeting room.
+
+        Raises
+        ------
+        ValueError
+            If a room with the same name already exists.
+        """
+
+        if room.name in self._rooms:
+            raise ValueError(f"Room '{room.name}' already exists.")
+        self._rooms[room.name] = room
+        self._room_index[room.name] = []
+
+    def remove_room(self, room_name: str) -> None:
+        """Remove a meeting room and all associated bookings."""
+
+        room_name = room_name.strip()
+        if room_name not in self._rooms:
+            raise KeyError(f"Room '{room_name}' does not exist.")
+        for booking_id in list(self._room_index[room_name]):
+            self._bookings.pop(booking_id, None)
+        del self._room_index[room_name]
+        del self._rooms[room_name]
+
+    def list_rooms(self) -> List[MeetingRoom]:
+        """Return all registered rooms sorted by name."""
+
+        return sorted(self._rooms.values(), key=lambda room: room.name)
+
+    def get_room(self, room_name: str) -> MeetingRoom:
+        """Retrieve room metadata by name."""
+
+        room_name = room_name.strip()
+        try:
+            return self._rooms[room_name]
+        except KeyError as exc:  # pragma: no cover - defensive programming
+            raise KeyError(f"Room '{room_name}' does not exist.") from exc
+
+    # ------------------------------------------------------------------
+    # Booking management
+    # ------------------------------------------------------------------
+    def book_room(
+        self,
+        *,
+        room_name: str,
+        start: datetime,
+        end: datetime,
+        title: str,
+        organizer: str,
+        attendees: Optional[Iterable[str]] = None,
+        notes: Optional[str] = None,
+    ) -> Booking:
+        """Reserve a room if it is available for the requested interval."""
+
+        room = self.get_room(room_name)
+        attendees_list = list(attendees or [])
+        new_booking = Booking(
+            id=str(uuid.uuid4()),
+            room=room,
+            start=start,
+            end=end,
+            title=title.strip() or room.name,
+            organizer=organizer.strip(),
+            attendees=attendees_list,
+            notes=notes.strip() if notes else None,
+        )
+
+        self._ensure_availability(new_booking)
+
+        self._bookings[new_booking.id] = new_booking
+        self._room_index[room.name].append(new_booking.id)
+        self._room_index[room.name].sort(key=lambda booking_id: self._bookings[booking_id].start)
+        return new_booking
+
+    def update_booking(
+        self,
+        booking_id: str,
+        *,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+        room_name: Optional[str] = None,
+        title: Optional[str] = None,
+        organizer: Optional[str] = None,
+        attendees: Optional[Sequence[str]] = None,
+        notes: Optional[str] = None,
+    ) -> Booking:
+        """Update an existing booking and return the modified booking."""
+
+        booking = self._bookings.get(booking_id)
+        if booking is None:
+            raise KeyError(f"Booking '{booking_id}' does not exist.")
+
+        target_room = self.get_room(room_name) if room_name else booking.room
+        new_start = start or booking.start
+        new_end = end or booking.end
+
+        updated_booking = Booking(
+            id=booking.id,
+            room=target_room,
+            start=new_start,
+            end=new_end,
+            title=title.strip() if title else booking.title,
+            organizer=organizer.strip() if organizer else booking.organizer,
+            attendees=list(attendees) if attendees is not None else list(booking.attendees),
+            notes=notes.strip() if notes else booking.notes,
+        )
+
+        # Temporarily remove the old booking to allow rescheduling.
+        self._remove_booking_from_index(booking)
+        try:
+            self._ensure_availability(updated_booking)
+        except Exception:
+            # If the update fails we must re-index the original booking.
+            self._room_index[booking.room.name].append(booking.id)
+            self._room_index[booking.room.name].sort(key=lambda b_id: self._bookings[b_id].start)
+            self._bookings[booking.id] = booking
+            raise
+        else:
+            self._bookings[booking.id] = updated_booking
+            self._room_index.setdefault(updated_booking.room.name, []).append(booking.id)
+            self._room_index[updated_booking.room.name].sort(
+                key=lambda b_id: self._bookings[b_id].start
+            )
+            return updated_booking
+
+    def cancel_booking(self, booking_id: str) -> Booking:
+        """Cancel a booking and return the cancelled booking."""
+
+        booking = self._bookings.pop(booking_id, None)
+        if booking is None:
+            raise KeyError(f"Booking '{booking_id}' does not exist.")
+        self._remove_booking_from_index(booking)
+        return booking
+
+    def list_bookings(
+        self,
+        *,
+        room_name: Optional[str] = None,
+        start: Optional[datetime] = None,
+        end: Optional[datetime] = None,
+    ) -> List[Booking]:
+        """Return bookings filtered by room and/or time range."""
+
+        if room_name:
+            booking_ids = self._room_index.get(room_name.strip(), [])
+            bookings = [self._bookings[booking_id] for booking_id in booking_ids]
+        else:
+            bookings = list(self._bookings.values())
+
+        filtered = []
+        for booking in bookings:
+            if start and booking.end <= start:
+                continue
+            if end and booking.start >= end:
+                continue
+            filtered.append(booking)
+        return sorted(filtered, key=lambda booking: (booking.room.name, booking.start))
+
+    def find_available_rooms(
+        self,
+        start: datetime,
+        end: datetime,
+        *,
+        capacity: Optional[int] = None,
+        resources: Optional[Iterable[str]] = None,
+    ) -> List[MeetingRoom]:
+        """Return rooms that are free for the provided time range."""
+
+        if start >= end:
+            raise ValueError("Start time must be before end time.")
+
+        required_resources: Set[str] = {resource.strip() for resource in resources or [] if resource.strip()}
+
+        available: List[MeetingRoom] = []
+        for room in self.list_rooms():
+            if capacity is not None and room.capacity < capacity:
+                continue
+            if required_resources and not required_resources.issubset(room.resources):
+                continue
+            probe = Booking(
+                id="__probe__",
+                room=room,
+                start=start,
+                end=end,
+                title="__probe__",
+                organizer="__probe__",
+            )
+            try:
+                self._ensure_availability(probe)
+            except ValueError:
+                continue
+            available.append(room)
+        return available
+
+    def get_booking(self, booking_id: str) -> Booking:
+        """Retrieve a booking by identifier."""
+
+        booking = self._bookings.get(booking_id)
+        if booking is None:
+            raise KeyError(f"Booking '{booking_id}' does not exist.")
+        return booking
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_availability(self, booking: Booking) -> None:
+        """Raise ``ValueError`` if the booking conflicts with existing reservations."""
+
+        for existing_id in self._room_index.get(booking.room.name, []):
+            existing = self._bookings[existing_id]
+            if booking.id == existing_id:
+                continue
+            if booking.overlaps(existing):
+                raise ValueError(
+                    "Room '{room}' is not available between {start:%Y-%m-%d %H:%M} and {end:%Y-%m-%d %H:%M}.".format(
+                        room=booking.room.name,
+                        start=booking.start,
+                        end=booking.end,
+                    )
+                )
+
+    def _remove_booking_from_index(self, booking: Booking) -> None:
+        booking_ids = self._room_index.get(booking.room.name, [])
+        try:
+            booking_ids.remove(booking.id)
+        except ValueError:
+            return
+
+
+__all__ = ["Booking", "BookingManager", "MeetingRoom"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ numpy==1.24.2
 pandas==2.0.0
 requests
 seaborn==0.12.2
+dash>=2.14.2
+plotly>=5.18.0

--- a/tests/test_meeting_room_booking.py
+++ b/tests/test_meeting_room_booking.py
@@ -1,0 +1,87 @@
+import unittest
+from datetime import datetime, timedelta
+
+from meeting_room_booking import BookingManager, MeetingRoom
+
+
+class BookingManagerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.manager = BookingManager()
+        self.manager.add_room(MeetingRoom(name="Atlas", capacity=8, resources={"TV", "Whiteboard"}))
+        self.manager.add_room(MeetingRoom(name="Zephyr", capacity=4, resources={"Phone"}))
+
+    def test_room_registration(self) -> None:
+        rooms = self.manager.list_rooms()
+        self.assertEqual([room.name for room in rooms], ["Atlas", "Zephyr"])
+        with self.assertRaises(ValueError):
+            self.manager.add_room(MeetingRoom(name="Atlas", capacity=10))
+
+    def test_booking_conflict_detection(self) -> None:
+        start = datetime(2024, 5, 10, 9, 0)
+        end = start + timedelta(hours=2)
+        self.manager.book_room(
+            room_name="Atlas",
+            start=start,
+            end=end,
+            title="Strategy Meeting",
+            organizer="alex@example.com",
+        )
+
+        with self.assertRaises(ValueError):
+            self.manager.book_room(
+                room_name="Atlas",
+                start=start + timedelta(minutes=30),
+                end=end + timedelta(hours=1),
+                title="Sales Review",
+                organizer="pat@example.com",
+            )
+
+    def test_find_available_rooms_with_filters(self) -> None:
+        start = datetime(2024, 5, 10, 13, 0)
+        end = start + timedelta(hours=1)
+        self.manager.book_room(
+            room_name="Atlas",
+            start=start,
+            end=end,
+            title="Design Review",
+            organizer="maya@example.com",
+        )
+
+        available = self.manager.find_available_rooms(start, end)
+        self.assertEqual([room.name for room in available], ["Zephyr"])
+
+        available = self.manager.find_available_rooms(start, end, capacity=6)
+        self.assertEqual(available, [])
+
+        available = self.manager.find_available_rooms(start, end, resources={"Phone"})
+        self.assertEqual([room.name for room in available], ["Zephyr"])
+
+    def test_update_and_cancel_booking(self) -> None:
+        start = datetime(2024, 5, 10, 9, 0)
+        end = start + timedelta(hours=1)
+        booking = self.manager.book_room(
+            room_name="Zephyr",
+            start=start,
+            end=end,
+            title="Daily Standup",
+            organizer="alex@example.com",
+        )
+
+        new_start = start + timedelta(hours=2)
+        new_end = new_start + timedelta(hours=1)
+        updated = self.manager.update_booking(booking.id, start=new_start, end=new_end, title="Project Sync")
+        self.assertEqual(updated.start, new_start)
+        self.assertEqual(updated.end, new_end)
+        self.assertEqual(updated.title, "Project Sync")
+
+        retrieved = self.manager.get_booking(booking.id)
+        self.assertEqual(retrieved.start, new_start)
+
+        cancelled = self.manager.cancel_booking(booking.id)
+        self.assertEqual(cancelled.id, booking.id)
+        with self.assertRaises(KeyError):
+            self.manager.get_booking(booking.id)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a reusable in-memory meeting room booking manager with APIs for rooms, reservations, and availability queries
- provide unit tests that cover room registration, conflict detection, availability filtering, and booking lifecycle actions

## Testing
- python -m unittest discover -s tests -p 'test*.py' -v

------
https://chatgpt.com/codex/tasks/task_e_68e670f944ec83268b496f7964ae178f